### PR TITLE
Fix for the iOS15 CoreBluetooth changes

### DIFF
--- a/iOS/RxBluetoothKit/RestoredState.swift
+++ b/iOS/RxBluetoothKit/RestoredState.swift
@@ -64,9 +64,18 @@ import CoreBluetooth
             guard let arrayOfAnyObjects = objects else { return [] }
             return arrayOfAnyObjects.compactMap { $0 as? CBService }
                 .map(RxCBService.init)
-                .map { Service(peripheral: Peripheral(manager: bluetoothManager,
-                                                      peripheral: RxCBPeripheral(peripheral: $0.service.peripheral)),
-                               service: $0) }
+                .compactMap {
+
+                    // Necessary to accomodate the changes between
+                    // iOS 14 and iOS 15
+                    let optPeripheral: CBPeripheral? = $0.service.peripheral
+                    guard let peripheral = optPeripheral else {
+                        return nil
+                    }
+
+                    return Service(peripheral: Peripheral(manager: bluetoothManager,
+                                                          peripheral: RxCBPeripheral(peripheral: peripheral)),
+                                   service: $0) }
         }
     }
 #endif

--- a/iOS/RxBluetoothKit/RxCBCharacteristic.swift
+++ b/iOS/RxBluetoothKit/RxCBCharacteristic.swift
@@ -31,6 +31,13 @@ class RxCBCharacteristic: RxCharacteristicType {
         self.characteristic = characteristic
     }
 
+    init?(characteristic: CBCharacteristic?) {
+        guard let characteristic = characteristic else {
+            return nil
+        }
+        self.characteristic = characteristic
+    }
+
     var objectId: UInt {
         return UInt(bitPattern: ObjectIdentifier(characteristic))
     }
@@ -55,7 +62,7 @@ class RxCBCharacteristic: RxCharacteristicType {
         return characteristic.descriptors?.map(RxCBDescriptor.init)
     }
 
-    var service: RxServiceType {
+    var service: RxServiceType? {
         return RxCBService(service: characteristic.service)
     }
 

--- a/iOS/RxBluetoothKit/RxCBDescriptor.swift
+++ b/iOS/RxBluetoothKit/RxCBDescriptor.swift
@@ -39,7 +39,7 @@ class RxCBDescriptor: RxDescriptorType {
         return descriptor.uuid
     }
 
-    var characteristic: RxCharacteristicType {
+    var characteristic: RxCharacteristicType? {
         return RxCBCharacteristic(characteristic: descriptor.characteristic)
     }
 

--- a/iOS/RxBluetoothKit/RxCBPeripheral.swift
+++ b/iOS/RxBluetoothKit/RxCBPeripheral.swift
@@ -54,7 +54,7 @@ class RxCBPeripheral: RxPeripheralType {
     }
 
     var services: [RxServiceType]? {
-        return peripheral.services?.map(RxCBService.init)
+        return peripheral.services?.compactMap(RxCBService.init)
     }
 
     var canSendWriteWithoutResponse: Bool {
@@ -247,7 +247,7 @@ class RxCBPeripheral: RxPeripheralType {
                                 \(peripheral.logDescription) didModifyServices(services:
                                 [\(invalidatedServices.logDescription))]
                                 """)
-            peripheralDidModifyServicesSubject.onNext(invalidatedServices.map(RxCBService.init))
+            peripheralDidModifyServicesSubject.onNext(invalidatedServices.compactMap(RxCBService.init))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral, didReadRSSI rssi: NSNumber, error: Error?) {
@@ -264,7 +264,7 @@ class RxCBPeripheral: RxPeripheralType {
                                 : \(String(describing: peripheral.services?.logDescription)),
                                 error: \(String(describing: error)))
                                 """)
-            peripheralDidDiscoverServicesSubject.onNext((peripheral.services?.map(RxCBService.init), error))
+            peripheralDidDiscoverServicesSubject.onNext((peripheral.services?.compactMap(RxCBService.init), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,

--- a/iOS/RxBluetoothKit/RxCBService.swift
+++ b/iOS/RxBluetoothKit/RxCBService.swift
@@ -30,6 +30,13 @@ class RxCBService: RxServiceType {
         self.service = service
     }
 
+    init?(service: CBService?) {
+        guard let service = service else {
+            return nil
+        }
+        self.service = service
+    }
+
     var objectId: UInt {
         return UInt(bitPattern: ObjectIdentifier(service))
     }
@@ -39,11 +46,11 @@ class RxCBService: RxServiceType {
     }
 
     var characteristics: [RxCharacteristicType]? {
-        return service.characteristics?.map(RxCBCharacteristic.init)
+        return service.characteristics?.compactMap(RxCBCharacteristic.init)
     }
 
     var includedServices: [RxServiceType]? {
-        return service.includedServices?.map(RxCBService.init)
+        return service.includedServices?.compactMap(RxCBService.init)
     }
 
     var isPrimary: Bool {

--- a/iOS/RxBluetoothKit/RxCharacteristicType.swift
+++ b/iOS/RxBluetoothKit/RxCharacteristicType.swift
@@ -30,7 +30,7 @@ protocol RxCharacteristicType {
     var isNotifying: Bool { get }
     var properties: CBCharacteristicProperties { get }
     var descriptors: [RxDescriptorType]? { get }
-    var service: RxServiceType { get }
+    var service: RxServiceType? { get }
 
     func isEqualTo(characteristic: RxCharacteristicType) -> Bool
 }

--- a/iOS/RxBluetoothKit/RxDescriptorType.swift
+++ b/iOS/RxBluetoothKit/RxDescriptorType.swift
@@ -29,7 +29,7 @@ protocol RxDescriptorType {
 
     var uuid: CBUUID { get }
 
-    var characteristic: RxCharacteristicType { get }
+    var characteristic: RxCharacteristicType? { get }
 
     var value: Any? { get }
 

--- a/iOS/RxSwift/Traits/Completable.swift
+++ b/iOS/RxSwift/Traits/Completable.swift
@@ -24,7 +24,7 @@ public enum CompletableEvent {
 }
 
 public extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Swift.Never {
-    public typealias CompletableObserver = (CompletableEvent) -> ()
+    typealias CompletableObserver = (CompletableEvent) -> ()
     
     /**
      Creates an observable sequence from a specified subscribe method implementation.
@@ -34,7 +34,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      - parameter subscribe: Implementation of the resulting observable sequence's `subscribe` method.
      - returns: The observable sequence with the specified implementation for the `subscribe` method.
      */
-    public static func create(subscribe: @escaping (@escaping CompletableObserver) -> Disposable) -> PrimitiveSequence<TraitType, ElementType> {
+    static func create(subscribe: @escaping (@escaping CompletableObserver) -> Disposable) -> PrimitiveSequence<TraitType, ElementType> {
         let source = Observable<ElementType>.create { observer in
             return subscribe { event in
                 switch event {
@@ -54,7 +54,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      
      - returns: Subscription for `observer` that can be used to cancel production of sequence elements and free resources.
      */
-    public func subscribe(_ observer: @escaping (CompletableEvent) -> ()) -> Disposable {
+    func subscribe(_ observer: @escaping (CompletableEvent) -> ()) -> Disposable {
         var stopped = false
         return self.primitiveSequence.asObservable().subscribe { event in
             if stopped { return }
@@ -78,7 +78,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      - parameter onError: Action to invoke upon errored termination of the observable sequence.
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(onCompleted: (() -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil) -> Disposable {
+    func subscribe(onCompleted: (() -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil) -> Disposable {
         #if DEBUG
                 let callStack = Hooks.recordCallStackOnError ? Thread.callStackSymbols : []
         #else
@@ -108,7 +108,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
 
      - returns: The observable sequence that terminates with specified error.
      */
-    public static func error(_ error: Swift.Error) -> Completable {
+    static func error(_ error: Swift.Error) -> Completable {
         return PrimitiveSequence(raw: Observable.error(error))
     }
 
@@ -119,7 +119,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
 
      - returns: An observable sequence whose observers will never get called.
      */
-    public static func never() -> Completable {
+    static func never() -> Completable {
         return PrimitiveSequence(raw: Observable.never())
     }
 
@@ -130,7 +130,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
 
      - returns: An observable sequence with no elements.
      */
-    public static func empty() -> Completable {
+    static func empty() -> Completable {
         return Completable(raw: Observable.empty())
     }
 
@@ -150,7 +150,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    public func `do`(onError: ((Swift.Error) throws -> Void)? = nil,
+    func `do`(onError: ((Swift.Error) throws -> Void)? = nil,
                      onCompleted: (() throws -> Void)? = nil,
                      onSubscribe: (() -> ())? = nil,
                      onSubscribed: (() -> ())? = nil,
@@ -175,7 +175,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      - parameter second: Second observable sequence.
      - returns: An observable sequence that contains the elements of `self`, followed by those of the second sequence.
      */
-    public func concat(_ second: Completable) -> Completable {
+    func concat(_ second: Completable) -> Completable {
         return Completable.concat(primitiveSequence, second)
     }
     
@@ -186,7 +186,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      
      - returns: An observable sequence that contains the elements of each given sequence, in sequential order.
      */
-    public static func concat<S: Sequence>(_ sequence: S) -> Completable
+    static func concat<S: Sequence>(_ sequence: S) -> Completable
         where S.Iterator.Element == Completable {
             let source = Observable.concat(sequence.lazy.map { $0.asObservable() })
             return Completable(raw: source)
@@ -199,7 +199,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      
      - returns: An observable sequence that contains the elements of each given sequence, in sequential order.
      */
-    public static func concat<C: Collection>(_ collection: C) -> Completable
+    static func concat<C: Collection>(_ collection: C) -> Completable
         where C.Iterator.Element == Completable {
             let source = Observable.concat(collection.map { $0.asObservable() })
             return Completable(raw: source)
@@ -212,7 +212,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      
      - returns: An observable sequence that contains the elements of each given sequence, in sequential order.
      */
-    public static func concat(_ sources: Completable ...) -> Completable {
+    static func concat(_ sources: Completable ...) -> Completable {
         let source = Observable.concat(sources.map { $0.asObservable() })
         return Completable(raw: source)
     }
@@ -225,7 +225,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      - parameter sources: Collection of observable sequences to merge.
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
-    public static func merge<C: Collection>(_ sources: C) -> Completable
+    static func merge<C: Collection>(_ sources: C) -> Completable
         where C.Iterator.Element == Completable {
             let source = Observable.merge(sources.map { $0.asObservable() })
             return Completable(raw: source)
@@ -239,7 +239,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      - parameter sources: Array of observable sequences to merge.
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
-    public static func merge(_ sources: [Completable]) -> Completable {
+    static func merge(_ sources: [Completable]) -> Completable {
         let source = Observable.merge(sources.map { $0.asObservable() })
         return Completable(raw: source)
     }
@@ -252,7 +252,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      - parameter sources: Collection of observable sequences to merge.
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
-    public static func merge(_ sources: Completable...) -> Completable {
+    static func merge(_ sources: Completable...) -> Completable {
         let source = Observable.merge(sources.map { $0.asObservable() })
         return Completable(raw: source)
     }

--- a/iOS/RxSwift/Traits/Maybe.swift
+++ b/iOS/RxSwift/Traits/Maybe.swift
@@ -27,7 +27,7 @@ public enum MaybeEvent<Element> {
 }
 
 public extension PrimitiveSequenceType where TraitType == MaybeTrait {
-    public typealias MaybeObserver = (MaybeEvent<ElementType>) -> ()
+    typealias MaybeObserver = (MaybeEvent<ElementType>) -> ()
     
     /**
      Creates an observable sequence from a specified subscribe method implementation.
@@ -37,7 +37,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter subscribe: Implementation of the resulting observable sequence's `subscribe` method.
      - returns: The observable sequence with the specified implementation for the `subscribe` method.
      */
-    public static func create(subscribe: @escaping (@escaping MaybeObserver) -> Disposable) -> PrimitiveSequence<TraitType, ElementType> {
+    static func create(subscribe: @escaping (@escaping MaybeObserver) -> Disposable) -> PrimitiveSequence<TraitType, ElementType> {
         let source = Observable<ElementType>.create { observer in
             return subscribe { event in
                 switch event {
@@ -60,7 +60,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      
      - returns: Subscription for `observer` that can be used to cancel production of sequence elements and free resources.
      */
-    public func subscribe(_ observer: @escaping (MaybeEvent<ElementType>) -> ()) -> Disposable {
+    func subscribe(_ observer: @escaping (MaybeEvent<ElementType>) -> ()) -> Disposable {
         var stopped = false
         return self.primitiveSequence.asObservable().subscribe { event in
             if stopped { return }
@@ -85,7 +85,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(onSuccess: ((ElementType) -> Void)? = nil,
+    func subscribe(onSuccess: ((ElementType) -> Void)? = nil,
                           onError: ((Swift.Error) -> Void)? = nil,
                           onCompleted: (() -> Void)? = nil) -> Disposable {
         #if DEBUG
@@ -120,7 +120,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter element: Single element in the resulting observable sequence.
      - returns: An observable sequence containing the single specified element.
      */
-    public static func just(_ element: ElementType) -> Maybe<ElementType> {
+    static func just(_ element: ElementType) -> Maybe<ElementType> {
         return Maybe(raw: Observable.just(element))
     }
     
@@ -133,7 +133,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter: Scheduler to send the single element on.
      - returns: An observable sequence containing the single specified element.
      */
-    public static func just(_ element: ElementType, scheduler: ImmediateSchedulerType) -> Maybe<ElementType> {
+    static func just(_ element: ElementType, scheduler: ImmediateSchedulerType) -> Maybe<ElementType> {
         return Maybe(raw: Observable.just(element, scheduler: scheduler))
     }
 
@@ -144,7 +144,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
 
      - returns: The observable sequence that terminates with specified error.
      */
-    public static func error(_ error: Swift.Error) -> Maybe<ElementType> {
+    static func error(_ error: Swift.Error) -> Maybe<ElementType> {
         return PrimitiveSequence(raw: Observable.error(error))
     }
 
@@ -155,7 +155,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
 
      - returns: An observable sequence whose observers will never get called.
      */
-    public static func never() -> Maybe<ElementType> {
+    static func never() -> Maybe<ElementType> {
         return PrimitiveSequence(raw: Observable.never())
     }
 
@@ -166,7 +166,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
 
      - returns: An observable sequence with no elements.
      */
-    public static func empty() -> Maybe<ElementType> {
+    static func empty() -> Maybe<ElementType> {
         return Maybe(raw: Observable.empty())
     }
 }
@@ -185,7 +185,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    public func `do`(onNext: ((ElementType) throws -> Void)? = nil,
+    func `do`(onNext: ((ElementType) throws -> Void)? = nil,
                      onError: ((Swift.Error) throws -> Void)? = nil,
                      onCompleted: (() throws -> Void)? = nil,
                      onSubscribe: (() -> ())? = nil,
@@ -210,7 +210,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter predicate: A function to test each source element for a condition.
      - returns: An observable sequence that contains elements from the input sequence that satisfy the condition.
      */
-    public func filter(_ predicate: @escaping (ElementType) throws -> Bool)
+    func filter(_ predicate: @escaping (ElementType) throws -> Bool)
         -> Maybe<ElementType> {
             return Maybe(raw: primitiveSequence.source.filter(predicate))
     }
@@ -224,7 +224,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
      
      */
-    public func map<R>(_ transform: @escaping (ElementType) throws -> R)
+    func map<R>(_ transform: @escaping (ElementType) throws -> R)
         -> Maybe<R> {
             return Maybe(raw: primitiveSequence.source.map(transform))
     }
@@ -237,7 +237,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter selector: A transform function to apply to each element.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
-    public func flatMap<R>(_ selector: @escaping (ElementType) throws -> Maybe<R>)
+    func flatMap<R>(_ selector: @escaping (ElementType) throws -> Maybe<R>)
         -> Maybe<R> {
             return Maybe<R>(raw: primitiveSequence.source.flatMap(selector))
     }
@@ -250,7 +250,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter default: Default element to be sent if the source does not emit any elements
      - returns: An observable sequence which emits default element end completes in case the original sequence is empty
      */
-    public func ifEmpty(default: ElementType) -> Single<ElementType> {
+    func ifEmpty(default: ElementType) -> Single<ElementType> {
         return Single(raw: primitiveSequence.source.ifEmpty(default: `default`))
     }
 
@@ -262,7 +262,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter switchTo: Observable sequence being returned when source sequence is empty.
      - returns: Observable sequence that contains elements from switchTo sequence if source is empty, otherwise returns source sequence elements.
      */
-    public func ifEmpty(switchTo other: Maybe<ElementType>) -> Maybe<ElementType> {
+    func ifEmpty(switchTo other: Maybe<ElementType>) -> Maybe<ElementType> {
         return Maybe(raw: primitiveSequence.source.ifEmpty(switchTo: other.primitiveSequence.source))
     }
 
@@ -274,7 +274,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter switchTo: Observable sequence being returned when source sequence is empty.
      - returns: Observable sequence that contains elements from switchTo sequence if source is empty, otherwise returns source sequence elements.
      */
-    public func ifEmpty(switchTo other: Single<ElementType>) -> Single<ElementType> {
+    func ifEmpty(switchTo other: Single<ElementType>) -> Single<ElementType> {
         return Single(raw: primitiveSequence.source.ifEmpty(switchTo: other.primitiveSequence.source))
     }
 
@@ -286,7 +286,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter element: Last element in an observable sequence in case error occurs.
      - returns: An observable sequence containing the source sequence's elements, followed by the `element` in case an error occurred.
      */
-    public func catchErrorJustReturn(_ element: ElementType)
+    func catchErrorJustReturn(_ element: ElementType)
         -> PrimitiveSequence<TraitType, ElementType> {
         return PrimitiveSequence(raw: primitiveSequence.source.catchErrorJustReturn(element))
     }


### PR DESCRIPTION
Some properties in CoreBluetooth have changed to optional. This changes addresses that issue.

Also, some warnings were removed