### PR TITLE
Added fix for, write characteristic returning null value in iOS

### DIFF
--- a/iOS/classes/BleModule.swift
+++ b/iOS/classes/BleModule.swift
@@ -858,7 +858,9 @@ public class BleClientManager : NSObject {
             }
             .subscribe(
                 onNext: { characteristic in
-                    promise.resolve(characteristic.asJSObject)
+                    var jsObject = characteristic.asJSObject;
+                    jsObject.updateValue(value.base64, forKey: "value")
+                    promise.resolve(jsObject)
                 },
                 onError: { error in
                     error.bleError.callReject(promise)


### PR DESCRIPTION
Hi,
Our team faced an issue while working with this package. The issue was, the characteristic returned after writing the value, always contained null, in iOS. The android works great though. So we dug in, and added a fix for that, by populating the value in the response of characteristic.asJSObject.  And, it started working well.